### PR TITLE
Improve brightness analysis UI and downloads

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -293,7 +293,14 @@ def plot_brightness(
     fig.update_layout(
         margin=dict(l=0, r=0, t=30, b=0),
         dragmode=dragmode,
-        coloraxis_colorbar=dict(title="pps" if not normalization else "log10(pps)"),
+        coloraxis_colorbar=dict(
+            title="pps" if not normalization else "log10(pps)",
+            yanchor="middle",
+            y=0.5,
+            lenmode="fraction",
+            len=0.8,
+            thickness=20,
+        ),
         xaxis_title="X (px)",
         yaxis_title="Y (px)"
     )
@@ -320,11 +327,13 @@ def plot_brightness(
             ))
         fig.update_layout(shapes=shapes)
 
-        # Centers with hover showing brightness
+        # Invisible markers for hover information only
         custom = np.stack([br], axis=1)
         fig.add_trace(go.Scatter(
-            x=xs, y=ys, mode="markers",
-            marker=dict(symbol="circle-open", size=10, line=dict(width=1.5, color="white")),
+            x=xs,
+            y=ys,
+            mode="markers",
+            marker=dict(size=1, opacity=0),
             name="Fits",
             customdata=custom,
             hovertemplate="x=%{x:.2f}px<br>y=%{y:.2f}px<br>brightness=%{customdata[0]:.1f} kpps<extra></extra>",


### PR DESCRIPTION
## Summary
- Move Analyze button to main area and relocate global heatmap toggle to sidebar.
- Improve brightness plot visuals by tightening colorbar spacing and removing inner centroid markers.
- Add HTML fallback for downloading brightness plots.

## Testing
- `python -m py_compile tools/analyze_single_sif.py utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c450a8aac083208407bfdc56d6e22e