### PR TITLE
Enhance interactive brightness tools and fix initialization errors

### DIFF
--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -155,7 +155,7 @@ def run():
                             mime=mime_map[save_format],
                         )
                     else:
-                        fig_image.update_layout(height=800)
+                        fig_image.update_layout(height=640)
                         st.plotly_chart(
                             fig_image,
                             use_container_width=True,
@@ -164,22 +164,17 @@ def run():
                                 "modeBarButtonsToRemove": ["select2d", "lasso2d", "toggleSpikelines"],
                             },
                         )
+                        import plotly.io as pio
                         try:
-                            img_bytes = fig_image.to_image(format=save_format)
+                            img_bytes = pio.to_image(fig_image, format=save_format)
                             st.download_button(
                                 label=f"Download PSFs ({save_format})",
                                 data=img_bytes,
                                 file_name=f"{selected_file_name}.{save_format}",
                                 mime=mime_map[save_format],
                             )
-                        except Exception:
-                            html_bytes = fig_image.to_html().encode("utf-8")
-                            st.download_button(
-                                label="Download PSFs (html)",
-                                data=html_bytes,
-                                file_name=f"{selected_file_name}.html",
-                                mime="text/html",
-                            )
+                        except Exception as e:
+                            st.warning(f"Static image export failed: {e}")
 
                     if combined_df is not None and not combined_df.empty:
                         csv_bytes = df_to_csv_bytes(combined_df)

--- a/tools/read_movie.py
+++ b/tools/read_movie.py
@@ -408,12 +408,12 @@ def run():
         export_fmt = st.selectbox("Download format", ["MP4", "MOV", "TIFF"], index=0)
 
     uploaded = st.file_uploader("Upload a .sif movie", type=["sif"], accept_multiple_files=False)
-    uploaded_name = uploaded.name  # e.g. "experiment1.sif"
-    base = os.path.splitext(os.path.basename(uploaded_name))[0]
-    today = date.today().strftime("%Y%m%d")
     if not uploaded:
         st.info("Upload a .sif file to begin.")
         return
+    uploaded_name = uploaded.name  # e.g. "experiment1.sif"
+    base = os.path.splitext(os.path.basename(uploaded_name))[0]
+    today = date.today().strftime("%Y%m%d")
 
     raw_frames = None
     frames_u8: List[np.ndarray] = []


### PR DESCRIPTION
## Summary
- Show pixel pps and PSF brightness in `analyze_single_sif` hover tooltips with smaller Plotly figure and proper image downloads
- Add interactive monomer brightness plotting with category legends and monotonic bin handling
- Prevent startup crash in Process Movie when no file is uploaded

## Testing
- `python -m py_compile utils.py tools/analyze_single_sif.py tools/monomers.py tools/read_movie.py`


------
https://chatgpt.com/codex/tasks/task_e_68c45a31619c83208d81c2305a25bdf5