### PR TITLE
Fix Plotly downloads and hover

### DIFF
--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -156,25 +156,25 @@ def run():
                         )
                     else:
                         fig_image.update_layout(height=640)
+                        fmt = save_format.lower()
+                        if fmt not in {"png", "jpeg", "jpg", "svg", "webp"}:
+                            fmt = "png"
                         st.plotly_chart(
                             fig_image,
                             use_container_width=True,
                             config={
                                 "displaylogo": False,
                                 "modeBarButtonsToRemove": ["select2d", "lasso2d", "toggleSpikelines"],
+                                "toImageButtonOptions": {"format": fmt},
                             },
                         )
-                        import plotly.io as pio
-                        try:
-                            img_bytes = pio.to_image(fig_image, format=save_format)
-                            st.download_button(
-                                label=f"Download PSFs ({save_format})",
-                                data=img_bytes,
-                                file_name=f"{selected_file_name}.{save_format}",
-                                mime=mime_map[save_format],
-                            )
-                        except Exception as e:
-                            st.warning(f"Static image export failed: {e}")
+                        html_bytes = fig_image.to_html().encode("utf-8")
+                        st.download_button(
+                            label="Download PSFs (HTML)",
+                            data=html_bytes,
+                            file_name=f"{selected_file_name}.html",
+                            mime="text/html",
+                        )
 
                     if combined_df is not None and not combined_df.empty:
                         csv_bytes = df_to_csv_bytes(combined_df)
@@ -224,24 +224,24 @@ def run():
                                 )
                             else:
                                 fig_hist.update_layout(height=400)
+                                fmt_h = save_format.lower()
+                                if fmt_h not in {"png", "jpeg", "jpg", "svg", "webp"}:
+                                    fmt_h = "png"
                                 st.plotly_chart(
                                     fig_hist,
                                     use_container_width=True,
                                     config={
                                         "displaylogo": False,
                                         "modeBarButtonsToRemove": ["select2d", "lasso2d", "toggleSpikelines"],
+                                        "toImageButtonOptions": {"format": fmt_h},
                                     },
                                 )
-                                try:
-                                    hist_bytes = fig_hist.to_image(format=save_format)
-                                    st.download_button(
-                                        label=f"Download histogram ({save_format})",
-                                        data=hist_bytes,
-                                        file_name=f"combined_histogram.{save_format}",
-                                        mime=mime_map[save_format],
-                                    )
-                                except Exception:
-                                    pass
+                                st.download_button(
+                                    label="Download histogram (HTML)",
+                                    data=fig_hist.to_html().encode("utf-8"),
+                                    file_name="combined_histogram.html",
+                                    mime="text/html",
+                                )
                         else:
                             st.warning("Min greater than max.")
             else:

--- a/utils.py
+++ b/utils.py
@@ -292,8 +292,12 @@ def plot_brightness(
         aspect="equal",
         color_continuous_scale=plotly_scale
     )
-    fig.data[0].customdata = img
-    fig.data[0].hovertemplate = "x=%{x:.0f}px<br>y=%{y:.0f}px<br>pps=%{customdata:.1f}<extra></extra>"
+    # store original cps values for accurate hover information
+    img_custom = np.expand_dims(img, axis=-1)
+    fig.data[0].customdata = img_custom
+    fig.data[0].hovertemplate = (
+        "x=%{x:.0f}px<br>y=%{y:.0f}px<br>pps=%{customdata[0]:.1f}<extra></extra>"
+    )
     fig.update_layout(
         margin=dict(l=0, r=0, t=30, b=0),
         dragmode=dragmode,
@@ -590,7 +594,7 @@ def plot_all_sifs(sif_files, df_dict, colocalization_radius=2, show_fits=True, n
     n_files = len(sif_files)
     n_cols = min(4, max(1, n_files))   # between 1 and 4, never more than files
     n_rows = int(np.ceil(n_files / n_cols))
-    fig, axes = plt.subplots(n_rows, n_cols, figsize=(16, 4 * n_rows))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(4 * n_cols, 4 * n_rows))
     if isinstance(axes, np.ndarray):
         axes = axes.flatten()
     else:


### PR DESCRIPTION
## Summary
- Fix Plotly hover text to show brightness values
- Remove Kaleido dependency from brightness and monomer tools by using browser-based downloads
- Keep SIF grid spacing consistent when only a few files are uploaded

## Testing
- `python -m py_compile utils.py tools/monomers.py tools/analyze_single_sif.py`


------
https://chatgpt.com/codex/tasks/task_e_68c464a21dcc83208feefbaff9eb6d26