### PR TITLE
Improve watershed coverage and update image display

### DIFF
--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -33,19 +33,12 @@ from matplotlib.lines import Line2D
 import numpy as np
 import plotly.graph_objects as go
 import streamlit as st
-from scipy.ndimage import distance_transform_edt
+from scipy import ndimage as ndi
 
-from skimage.morphology import (
-    remove_small_objects,
-    remove_small_holes,
-    binary_closing,
-    binary_opening,
-    disk,
-)
-from skimage.filters import gaussian
+from skimage import morphology as morph
+from skimage import segmentation as seg
 from skimage.feature import peak_local_max
 from skimage.measure import label, regionprops
-from skimage.segmentation import watershed
 from sklearn.mixture import GaussianMixture
 
 
@@ -590,36 +583,68 @@ def segment_and_measure_shapes(
     Dict with measurement arrays and PNG overlays.
     """
 
+    if measurement_unit == "nm" and np.isfinite(nm_per_px) and nm_per_px > 0:
+        scale_factor = nm_per_px
+        exclusion_zone_px = 2.0 / nm_per_px
+        min_linear_px = max(min_size_value / nm_per_px, 1.0)
+    else:
+        scale_factor = 1.0
+        exclusion_zone_px = 0.0
+        min_linear_px = max(min_size_value, 1.0)
+
+    approx_min_area = math.pi * (min_linear_px / 2.0) ** 2 if min_linear_px > 0 else float(min_area_px)
+    if not math.isfinite(approx_min_area) or approx_min_area <= 0:
+        approx_min_area = float(min_area_px)
+    area_keep_threshold = max(int(math.ceil(approx_min_area)), int(min_area_px))
+    hole_area_threshold = max(int(math.ceil(approx_min_area * 0.5)), int(4 * min_area_px))
+
     # Binary image and watershed segmentation
-    smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    im_bi = smoothed < threshold
-    im_bi = binary_closing(im_bi, disk(2))
-    im_bi = binary_opening(im_bi, disk(1))
-    hole_area = max(int(min_area_px * 4), 16)
-    im_bi = remove_small_holes(im_bi, area_threshold=hole_area)
-    im_bi = im_bi.astype(bool)
+    im_bi = data < threshold
+    im_bi = morph.binary_closing(im_bi, morph.disk(3))
+    im_bi = morph.remove_small_objects(im_bi, min_size=max(min_area_px, 32))
 
     if np.any(im_bi):
-        dist = distance_transform_edt(im_bi)
-        smoothed_dist = gaussian(dist, sigma=1.0, preserve_range=True)
-        local_max = peak_local_max(
-            smoothed_dist,
-            footprint=np.ones((3, 3), dtype=bool),
-            labels=im_bi,
-            threshold_abs=0.0,
-        )
-        if local_max.size == 0:
-            markers = label(im_bi)
+        distance_map = ndi.distance_transform_edt(im_bi)
+        distance_smooth = ndi.gaussian_filter(distance_map, sigma=0.8)
+        dt_vals = distance_smooth[im_bi]
+        if dt_vals.size:
+            h_candidate = float(np.percentile(dt_vals, 90) * 0.2)
+            h_val = float(np.clip(h_candidate, 0.6, 3.0))
         else:
-            marker_mask = np.zeros_like(im_bi, dtype=bool)
-            marker_mask[tuple(local_max.T)] = True
-            markers = label(marker_mask)
-        labels_ws = watershed(-smoothed_dist, markers=markers, mask=im_bi)
-        refined_mask = labels_ws > 0
-        refined_mask = remove_small_objects(refined_mask, min_size=max(min_area_px, 3))
-        refined_mask = remove_small_holes(refined_mask, area_threshold=hole_area)
-        labels_ws = label(refined_mask)
-        im_bi = refined_mask
+            h_val = 0.8
+        markers_bin = morph.h_maxima(distance_smooth, h=h_val)
+        markers = label(markers_bin)
+
+        if markers.max() <= 1:
+            min_distance = max(int(round(min_linear_px / 2.5)), 1)
+            peak_coords = peak_local_max(
+                distance_smooth,
+                min_distance=min_distance,
+                labels=im_bi,
+                exclude_border=False,
+            )
+            marker_mask = np.zeros_like(distance_smooth, dtype=bool)
+            if peak_coords.size:
+                marker_mask[tuple(peak_coords.T)] = True
+            fallback_markers = label(marker_mask)
+            if fallback_markers.max() > 1:
+                markers = fallback_markers
+            elif fallback_markers.max() == 0:
+                markers = label(im_bi)
+
+        labels_ws = seg.watershed(-distance_smooth, markers=markers, mask=im_bi)
+        im_bi_split = im_bi.copy()
+        im_bi_split[labels_ws == 0] = False
+        im_bi_filtered = morph.remove_small_objects(
+            im_bi_split,
+            min_size=area_keep_threshold,
+        )
+        im_bi_filtered = morph.remove_small_holes(
+            im_bi_filtered,
+            area_threshold=hole_area_threshold,
+        )
+        labels_ws = label(im_bi_filtered)
+        im_bi = im_bi_filtered
     else:
         labels_ws = np.zeros_like(data, dtype=np.int32)
 
@@ -629,13 +654,6 @@ def segment_and_measure_shapes(
     lengths_nm: List[float] = []
     widths_nm: List[float] = []
 
-    # Determine scaling and exclusion zone based on available calibration
-    if measurement_unit == "nm" and np.isfinite(nm_per_px) and nm_per_px > 0:
-        scale_factor = nm_per_px
-        exclusion_zone_px = 2 / nm_per_px
-    else:
-        scale_factor = 1.0
-        exclusion_zone_px = 0.0
     img_h, img_w = data.shape
 
     aspect_ratio = img_w / img_h if img_h else 1.0
@@ -1427,12 +1445,12 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
                         caption = f"Intensity histogram (threshold={threshold_value:.4f})"
                     else:
                         caption = "Intensity histogram"
-                    st.image(hist_png, caption=caption, use_column_width=True)
+                    st.image(hist_png, caption=caption, use_container_width=True)
                 else:
                     st.caption("Intensity histogram unavailable.")
             with col_ws:
                 if ws_png:
-                    st.image(ws_png, caption="Watershed labels", use_column_width=True)
+                    st.image(ws_png, caption="Watershed labels", use_container_width=True)
                 else:
                     st.caption("Watershed labels unavailable.")
 


### PR DESCRIPTION
## Summary
- adopt MATLAB-style binarization and closing before watershed so more foreground shapes survive
- use distance-transform h-maxima markers and watershed ridge removal to better match MATLAB segmentation results
- tune watershed marker detection and post-processing area thresholds so clustered particles are retained instead of being filtered out

## Testing
- python -m compileall tools/spherical_tem.py

------
https://chatgpt.com/codex/tasks/task_e_68cad8fc91f08320b8f87dfd69931621