### PR TITLE
Add CSV download to monomer view

### DIFF
--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -419,6 +419,17 @@ def run():
                     file_name=f"{selected_file_name}.html",
                     mime="text/html",
                 )
+
+                if combined_df is not None and not combined_df.empty:
+                    csv_bytes = df_to_csv_bytes(combined_df)
+                    st.download_button(
+                        label="Download as CSV",
+                        data=csv_bytes,
+                        file_name=f"{os.path.splitext(selected_file_name)[0]}_compiled.csv",
+                        mime="text/csv",
+                    )
+                else:
+                    st.info("No compiled data available to download yet.")
             else:
                 st.error(f"Data for file '{selected_file_name}' not found.")
 


### PR DESCRIPTION
## Summary
- add a CSV download button to the monomer analysis page so compiled data can be exported
- display an informational message when compiled data is not yet available

## Testing
- not run (streamlit UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cc1cc67160832094e678bd5885991b