### PR TITLE
Make download file names reflect selected data

### DIFF
--- a/tools/SaturationSeries.py
+++ b/tools/SaturationSeries.py
@@ -280,6 +280,7 @@ def run():
                 selected_file = st.selectbox("Select SIF to display:", options=file_options, key="file_select")
                 
                 if selected_file:
+                    selected_file_base = os.path.splitext(selected_file)[0]
                     plot_col1, plot_col2 = st.columns(2)
                     data_for_file = processed_data[selected_file]
                     unfiltered_df = data_for_file.get("df")
@@ -310,7 +311,11 @@ def run():
                         st.pyplot(fig_image)
                         svg_buffer_img = io.StringIO()
                         fig_image.savefig(svg_buffer_img, format='svg')
-                        st.download_button("Download Image (SVG)", svg_buffer_img.getvalue(), f"{selected_file}.svg")
+                        st.download_button(
+                            "Download Image (SVG)",
+                            svg_buffer_img.getvalue(),
+                            f"{selected_file_base}.svg"
+                        )
 
                     with plot_col2:
                         st.markdown("#### Brightness Histogram")
@@ -329,10 +334,18 @@ def run():
                             
                             svg_buffer_hist = io.StringIO()
                             fig_hist.savefig(svg_buffer_hist, format='svg')
-                            st.download_button("Download Histogram (SVG)", svg_buffer_hist.getvalue(), f"{selected_file}_histogram.svg")
-                            
+                            st.download_button(
+                                "Download Histogram (SVG)",
+                                svg_buffer_hist.getvalue(),
+                                f"{selected_file_base}_histogram.svg"
+                            )
+
                             csv_bytes = df_to_csv_bytes(df_for_file)
-                            st.download_button("Download Data (CSV)", csv_bytes, f"{selected_file}_data.csv")
+                            st.download_button(
+                                "Download Data (CSV)",
+                                csv_bytes,
+                                f"{selected_file_base}_data.csv"
+                            )
                         else:
                             st.info(f"No particles were detected in '{selected_file}'.")
 

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -127,6 +127,7 @@ def run():
                 selected_file_name = uploaded_files[0].name
 
             if selected_file_name in processed_data:
+                selected_file_base = os.path.splitext(selected_file_name)[0]
                 data_to_plot = processed_data[selected_file_name]
                 df_selected = data_to_plot["df"]
                 image_data_cps = data_to_plot["image"]
@@ -151,7 +152,7 @@ def run():
                         st.download_button(
                             label=f"Download PSFs ({save_format})",
                             data=buffer.getvalue(),
-                            file_name=f"{selected_file_name}.{save_format}",
+                            file_name=f"{selected_file_base}.{save_format}",
                             mime=mime_map[save_format],
                         )
                     else:
@@ -172,7 +173,7 @@ def run():
                         st.download_button(
                             label="Download PSFs (HTML)",
                             data=html_bytes,
-                            file_name=f"{selected_file_name}.html",
+                            file_name=f"{selected_file_base}.html",
                             mime="text/html",
                         )
 
@@ -219,7 +220,7 @@ def run():
                                 st.download_button(
                                     label=f"Download histogram ({save_format})",
                                     data=hist_buffer.getvalue(),
-                                    file_name=f"combined_histogram.{save_format}",
+                                    file_name=f"{selected_file_base}_histogram.{save_format}",
                                     mime=mime_map[save_format],
                                 )
                             else:
@@ -239,7 +240,7 @@ def run():
                                 st.download_button(
                                     label="Download histogram (HTML)",
                                     data=fig_hist.to_html().encode("utf-8"),
-                                    file_name="combined_histogram.html",
+                                    file_name=f"{selected_file_base}_histogram.html",
                                     mime="text/html",
                                 )
                         else:
@@ -301,10 +302,15 @@ def run():
 
                     hm_svg_buf = io.StringIO()
                     fig_hm.savefig(hm_svg_buf, format="svg")
+                    heatmap_base = (
+                        os.path.splitext(selected_file_name)[0]
+                        if "selected_file_name" in locals() and selected_file_name
+                        else "brightness_heatmap"
+                    )
                     st.download_button(
                         label="Download heatmap",
                         data=hm_svg_buf.getvalue(),
-                        file_name="brightness_heatmap.svg",
+                        file_name=f"{heatmap_base}_heatmap.svg",
                         mime="image/svg+xml",
                     )
 

--- a/tools/colocalization.py
+++ b/tools/colocalization.py
@@ -251,6 +251,16 @@ def run():
     pairs = _match_ucnp_dye_files(u_names, d_names)
     st.caption(f"Matched {len(pairs)} UCNP↔Dye pairs.")
 
+    if pairs:
+        first_u, first_d = pairs[0]
+        base_u = os.path.splitext(os.path.basename(first_u))[0]
+        base_d = os.path.splitext(os.path.basename(first_d))[0]
+        extra_suffix = f"_plus{len(pairs) - 1}" if len(pairs) > 1 else ""
+        selected_file_name = f"{base_u}_{base_d}{extra_suffix}.pair"
+    else:
+        selected_file_name = "colocalization.pair"
+    selected_file_base = os.path.splitext(selected_file_name)[0]
+
     # Prepare Matplotlib
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
@@ -376,7 +386,7 @@ def run():
         st.download_button(
             "Download colocalized pairs (CSV)",
             data=matched_df.to_csv(index=False).encode("utf-8"),
-            file_name="colocalized_pairs.csv",
+            file_name=f"{selected_file_base}_colocalized_pairs.csv",
             mime="text/csv",
         )
 
@@ -457,7 +467,7 @@ def run():
                 st.download_button(
                     "Download thresholded results (CSV)",
                     data=thresholded_df.to_csv(index=False).encode("utf-8"),
-                    file_name="thresholded_results.csv",
+                    file_name=f"{selected_file_base}_thresholded_results.csv",
                     mime="text/csv",
                 )
 if __name__ == "__main__":

--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -416,7 +416,7 @@ def run():
                 st.download_button(
                     label="Download PSFs (HTML)",
                     data=html_bytes,
-                    file_name=f"{selected_file_name}.html",
+                    file_name=f"{os.path.splitext(selected_file_name)[0]}.html",
                     mime="text/html",
                 )
 

--- a/tools/plot_csv.py
+++ b/tools/plot_csv.py
@@ -1,6 +1,7 @@
 
 import io
 import json
+import os
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -54,6 +55,12 @@ def run():
       smooth_window = st.slider("Rolling window size", 3, 101, 9, step=2)
       group_agg = st.selectbox("If multiple rows per group, aggregate Y using:", ["None", "mean", "median"])
       download_cleaned = st.checkbox("Enable download of cleaned/reshaped data", value=True)
+
+  if uploaded is not None:
+      selected_file_name = uploaded.name
+  else:
+      selected_file_name = "example_data.csv" if use_example else "plotted_data.csv"
+  selected_file_stem = os.path.splitext(selected_file_name)[0]
   
   # Helper palettes
   PLOTLY_PALETTES = {
@@ -272,7 +279,12 @@ def run():
   
       if download_cleaned:
           csv = long_df.to_csv(index=False).encode("utf-8")
-          st.download_button("⬇️ Download plotted data (CSV)", data=csv, file_name="plotted_data.csv", mime="text/csv")
+          st.download_button(
+              "⬇️ Download plotted data (CSV)",
+              data=csv,
+              file_name=f"{selected_file_stem}_plotted_data.csv",
+              mime="text/csv",
+          )
   
   def draw_paired_plot(tidy: pd.DataFrame):
       if tidy.empty:
@@ -310,7 +322,12 @@ def run():
   
       if download_cleaned:
           csv = plot_df.to_csv(index=False).encode("utf-8")
-          st.download_button("⬇️ Download plotted data (CSV)", data=csv, file_name="plotted_data_paired.csv", mime="text/csv")
+          st.download_button(
+              "⬇️ Download plotted data (CSV)",
+              data=csv,
+              file_name=f"{selected_file_stem}_plotted_data_paired.csv",
+              mime="text/csv",
+          )
   
   # Load data
   if uploaded is not None:


### PR DESCRIPTION
## Summary
- derive download file names in the SIF analysis, monomer, and saturation series tools from the chosen SIF so saved assets inherit the source name
- propagate selected dataset names through the CSV plotter and colocalization outputs to avoid generic download titles

## Testing
- python -m compileall tools

------
https://chatgpt.com/codex/tasks/task_e_68cc1f29ca3c8320ba0736d545920bc4