### PR TITLE
Fix cached PSF reuse and skip redundant fits

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -177,9 +177,9 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um=0.1
         if cached_result is _SKIP_RESULT:
             continue
         if cached_result is not None:
-            # A prior candidate already fit this PSF; skip duplicating it.
-
-            results.append(cached_result.copy)
+            # A prior candidate already fit this PSF; reuse it without refitting.
+            results.append(cached_result.copy())
+            continue
 
         # Extract finer subregion
         sub_img_fine, x0_idx_fine, y0_idx_fine = extract_subregion(


### PR DESCRIPTION
## Summary
- ensure cached PSF results in `integrate_sif` are copied correctly
- skip redundant refitting by returning early when a cached PSF result exists

## Testing
- python -m compileall utils.py tools/monomers.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5b40cbf88320af3b8d49fb4f73cc