### PR TITLE
Add repo update timestamp banner to Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,16 +6,52 @@ import importlib
 import importlib.util
 from importlib import metadata as importlib_metadata
 import platform
+import subprocess
+from datetime import datetime, timezone
 import streamlit as st
 
 # Ensure local imports work when running "streamlit run app.py"
-sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+REPO_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+sys.path.append(REPO_ROOT)
+
+
+def _repo_last_updated(repo_path: str) -> str:
+    """Return a human-readable timestamp for the last git commit in ``repo_path``."""
+
+    try:
+        timestamp_raw = subprocess.check_output(
+            ["git", "-C", repo_path, "log", "-1", "--format=%ct"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+    if not timestamp_raw:
+        return "unknown"
+
+    try:
+        timestamp = datetime.fromtimestamp(int(timestamp_raw), tz=timezone.utc).astimezone()
+    except (ValueError, OSError, OverflowError):
+        return "unknown"
+
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 # --- Page setup ---
 try:
     st.set_page_config(layout="wide")
 except Exception:
     pass
+
+st.markdown(
+    (
+        "<div style='display:flex; justify-content:flex-end; margin-bottom:0.5rem; color:#5c5c5c;'>"
+        f"<span style='font-size:0.9rem;'>Last repository update: {_repo_last_updated(REPO_ROOT)}</span>"
+        "</div>"
+    ),
+    unsafe_allow_html=True,
+)
 
 st.sidebar.title("Tools")
 


### PR DESCRIPTION
## Summary
- add a helper that reads the last git commit timestamp for the repository
- surface the repository update timestamp at the top-right of the Streamlit app layout

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cda435291c832087ce560613eb3959