### PR TITLE
Fix sigma bounds handling in integrate_sif

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Python 3",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "app.py"
+      ]
+    },
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
+  "postAttachCommand": {
+    "server": "streamlit run app.py --server.enableCORS false --server.enableXsrfProtection false"
+  },
+  "portsAttributes": {
+    "8501": {
+      "label": "Application",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "forwardPorts": [
+    8501
+  ]
+}

--- a/app.py
+++ b/app.py
@@ -145,13 +145,6 @@ def safe_run_tool(modpath: str, funcname: str, label: str):
             return run_fn()
         except Exception as e:
             render_error_context(f"{label} crashed while running", e)
-            with st.expander("Quick things to check"):
-                st.markdown(
-                    "- Are the input files/paths valid?\n"
-                    "- Did package versions change (e.g., scikit-image, scipy, sklearn)?\n"
-                    "- Any GPU/driver issues for heavy operations?\n"
-                    "- Toggle 'Show error tracebacks' above to see details."
-                )
             return
 
 if tool_label in label_to_key:

--- a/app.py
+++ b/app.py
@@ -6,16 +6,52 @@ import importlib
 import importlib.util
 from importlib import metadata as importlib_metadata
 import platform
+import subprocess
+from datetime import datetime, timezone
 import streamlit as st
 
 # Ensure local imports work when running "streamlit run app.py"
-sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+REPO_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+sys.path.append(REPO_ROOT)
+
+
+def _repo_last_updated(repo_path: str) -> str:
+    """Return a human-readable timestamp for the last git commit in ``repo_path``."""
+
+    try:
+        timestamp_raw = subprocess.check_output(
+            ["git", "-C", repo_path, "log", "-1", "--format=%ct"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+    if not timestamp_raw:
+        return "unknown"
+
+    try:
+        timestamp = datetime.fromtimestamp(int(timestamp_raw), tz=timezone.utc).astimezone()
+    except (ValueError, OSError, OverflowError):
+        return "unknown"
+
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 # --- Page setup ---
 try:
     st.set_page_config(layout="wide")
 except Exception:
     pass
+
+st.markdown(
+    (
+        "<div style='display:flex; justify-content:flex-end; margin-bottom:0.5rem; color:#5c5c5c;'>"
+        f"<span style='font-size:0.9rem;'>Last repository update: {_repo_last_updated(REPO_ROOT)}</span>"
+        "</div>"
+    ),
+    unsafe_allow_html=True,
+)
 
 st.sidebar.title("Tools")
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ tool_registry = {
     "Monomer Estimation": ("tools.monomers", "run"),
     "Process Movie": ("tools.read_movie", "run"),
     # "Plot CSVs": ("tools.plot_csv", "run"),  # commented like your original
-    "Spherical NP TEM": ("tools.spherical_tem", "run"),
+    "TEM Size Analysis": ("tools.spherical_tem", "run"),
 }
 
 show_traces = st.sidebar.toggle(

--- a/tools/SaturationSeries.py
+++ b/tools/SaturationSeries.py
@@ -280,6 +280,7 @@ def run():
                 selected_file = st.selectbox("Select SIF to display:", options=file_options, key="file_select")
                 
                 if selected_file:
+                    selected_file_base = os.path.splitext(selected_file)[0]
                     plot_col1, plot_col2 = st.columns(2)
                     data_for_file = processed_data[selected_file]
                     unfiltered_df = data_for_file.get("df")
@@ -310,7 +311,11 @@ def run():
                         st.pyplot(fig_image)
                         svg_buffer_img = io.StringIO()
                         fig_image.savefig(svg_buffer_img, format='svg')
-                        st.download_button("Download Image (SVG)", svg_buffer_img.getvalue(), f"{selected_file}.svg")
+                        st.download_button(
+                            "Download Image (SVG)",
+                            svg_buffer_img.getvalue(),
+                            f"{selected_file_base}.svg"
+                        )
 
                     with plot_col2:
                         st.markdown("#### Brightness Histogram")
@@ -329,10 +334,18 @@ def run():
                             
                             svg_buffer_hist = io.StringIO()
                             fig_hist.savefig(svg_buffer_hist, format='svg')
-                            st.download_button("Download Histogram (SVG)", svg_buffer_hist.getvalue(), f"{selected_file}_histogram.svg")
-                            
+                            st.download_button(
+                                "Download Histogram (SVG)",
+                                svg_buffer_hist.getvalue(),
+                                f"{selected_file_base}_histogram.svg"
+                            )
+
                             csv_bytes = df_to_csv_bytes(df_for_file)
-                            st.download_button("Download Data (CSV)", csv_bytes, f"{selected_file}_data.csv")
+                            st.download_button(
+                                "Download Data (CSV)",
+                                csv_bytes,
+                                f"{selected_file_base}_data.csv"
+                            )
                         else:
                             st.info(f"No particles were detected in '{selected_file}'.")
 

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -88,8 +88,8 @@ def run():
         -UCNP signal sets absolute peak cut off
         -Dye signal sets sensitivity of blob detection
         ''')
-        diagram = """ Splits sif into quadrants (256x256 px):
-          ┌─┬─┐  
+        diagram = """ Splits sif into quadrants (256x256 px):  
+        ┌─┬─┐  
         │ 1 │ 2 │  
         ├─┼─┤  
         │ 3 │ 4 │  

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -89,11 +89,11 @@ def run():
         -Dye signal sets sensitivity of blob detection
         ''')
         diagram = """ Splits sif into quadrants (256x256 px):
-        ┌─┬─┐
-        │ 1 │ 2 │
-        ├─┼─┤
-        │ 3 │ 4 │
-        └─┴─┘
+        ┌─┬─┐  
+        │ 1 │ 2 │  
+        ├─┼─┤  
+        │ 3 │ 4 │  
+        └─┴─┘  
         """
         region = st.selectbox("Region", options=["1", "2", "3", "4", "all"], help=diagram)
 

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -127,6 +127,7 @@ def run():
                 selected_file_name = uploaded_files[0].name
 
             if selected_file_name in processed_data:
+                selected_file_base = os.path.splitext(selected_file_name)[0]
                 data_to_plot = processed_data[selected_file_name]
                 df_selected = data_to_plot["df"]
                 image_data_cps = data_to_plot["image"]
@@ -151,7 +152,7 @@ def run():
                         st.download_button(
                             label=f"Download PSFs ({save_format})",
                             data=buffer.getvalue(),
-                            file_name=f"{selected_file_name}.{save_format}",
+                            file_name=f"{selected_file_base}.{save_format}",
                             mime=mime_map[save_format],
                         )
                     else:
@@ -172,7 +173,7 @@ def run():
                         st.download_button(
                             label="Download PSFs (HTML)",
                             data=html_bytes,
-                            file_name=f"{selected_file_name}.html",
+                            file_name=f"{selected_file_base}.html",
                             mime="text/html",
                         )
 
@@ -219,7 +220,7 @@ def run():
                                 st.download_button(
                                     label=f"Download histogram ({save_format})",
                                     data=hist_buffer.getvalue(),
-                                    file_name=f"combined_histogram.{save_format}",
+                                    file_name=f"{selected_file_base}_histogram.{save_format}",
                                     mime=mime_map[save_format],
                                 )
                             else:
@@ -239,7 +240,7 @@ def run():
                                 st.download_button(
                                     label="Download histogram (HTML)",
                                     data=fig_hist.to_html().encode("utf-8"),
-                                    file_name="combined_histogram.html",
+                                    file_name=f"{selected_file_base}_histogram.html",
                                     mime="text/html",
                                 )
                         else:
@@ -301,10 +302,15 @@ def run():
 
                     hm_svg_buf = io.StringIO()
                     fig_hm.savefig(hm_svg_buf, format="svg")
+                    heatmap_base = (
+                        os.path.splitext(selected_file_name)[0]
+                        if "selected_file_name" in locals() and selected_file_name
+                        else "brightness_heatmap"
+                    )
                     st.download_button(
                         label="Download heatmap",
                         data=hm_svg_buf.getvalue(),
-                        file_name="brightness_heatmap.svg",
+                        file_name=f"{heatmap_base}_heatmap.svg",
                         mime="image/svg+xml",
                     )
 

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -89,7 +89,7 @@ def run():
         -Dye signal sets sensitivity of blob detection
         ''')
         diagram = """ Splits sif into quadrants (256x256 px):
-        ┌─┬─┐  
+          ┌─┬─┐  
         │ 1 │ 2 │  
         ├─┼─┤  
         │ 3 │ 4 │  

--- a/tools/analyze_single_sif.py
+++ b/tools/analyze_single_sif.py
@@ -101,7 +101,7 @@ def run():
                                                                 - UCNP for high SNR (sklearn peakfinder)
                                                                 - dye for low SNR (sklearn blob detection)''')
         cmap = st.selectbox("Colormap", options=['plasma', 'gray', "magma", 'viridis', 'hot', 'hsv'])
-        show_fits = st.checkbox("Show fits")
+        show_fits = st.checkbox("Show fits", value = True)
         normalization = st.checkbox("Log Image Scaling")
         save_format = st.selectbox("Download format", options=["svg", "png", "jpeg"]).lower()
         show_heatmap = st.toggle(

--- a/tools/colocalization.py
+++ b/tools/colocalization.py
@@ -251,6 +251,16 @@ def run():
     pairs = _match_ucnp_dye_files(u_names, d_names)
     st.caption(f"Matched {len(pairs)} UCNP↔Dye pairs.")
 
+    if pairs:
+        first_u, first_d = pairs[0]
+        base_u = os.path.splitext(os.path.basename(first_u))[0]
+        base_d = os.path.splitext(os.path.basename(first_d))[0]
+        extra_suffix = f"_plus{len(pairs) - 1}" if len(pairs) > 1 else ""
+        selected_file_name = f"{base_u}_{base_d}{extra_suffix}.pair"
+    else:
+        selected_file_name = "colocalization.pair"
+    selected_file_base = os.path.splitext(selected_file_name)[0]
+
     # Prepare Matplotlib
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
@@ -376,7 +386,7 @@ def run():
         st.download_button(
             "Download colocalized pairs (CSV)",
             data=matched_df.to_csv(index=False).encode("utf-8"),
-            file_name="colocalized_pairs.csv",
+            file_name=f"{selected_file_base}_colocalized_pairs.csv",
             mime="text/csv",
         )
 
@@ -457,7 +467,7 @@ def run():
                 st.download_button(
                     "Download thresholded results (CSV)",
                     data=thresholded_df.to_csv(index=False).encode("utf-8"),
-                    file_name="thresholded_results.csv",
+                    file_name=f"{selected_file_base}_thresholded_results.csv",
                     mime="text/csv",
                 )
 if __name__ == "__main__":

--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -419,6 +419,17 @@ def run():
                     file_name=f"{selected_file_name}.html",
                     mime="text/html",
                 )
+
+                if combined_df is not None and not combined_df.empty:
+                    csv_bytes = df_to_csv_bytes(combined_df)
+                    st.download_button(
+                        label="Download as CSV",
+                        data=csv_bytes,
+                        file_name=f"{os.path.splitext(selected_file_name)[0]}_compiled.csv",
+                        mime="text/csv",
+                    )
+                else:
+                    st.info("No compiled data available to download yet.")
             else:
                 st.error(f"Data for file '{selected_file_name}' not found.")
 

--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -416,7 +416,7 @@ def run():
                 st.download_button(
                     label="Download PSFs (HTML)",
                     data=html_bytes,
-                    file_name=f"{selected_file_name}.html",
+                    file_name=f"{os.path.splitext(selected_file_name)[0]}.html",
                     mime="text/html",
                 )
 

--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -255,7 +255,8 @@ def _process_files_cached(saved_records, region, threshold, signal, pix_size_um=
         pix_size_um=pix_size_um,
         sig_threshold=sig_threshold,
     )
-
+def df_to_csv_bytes(df):
+    return df.to_csv(index=False).encode("utf-8")
 
 def run():
     col1, col2 = st.columns([1, 2])

--- a/tools/monomers.py
+++ b/tools/monomers.py
@@ -101,7 +101,7 @@ def plot_monomer_brightness(
             for _, row in df.iterrows():
                 x_px = row['x_pix']
                 y_px = row['y_pix']
-                brightness_pps = row['brightness_fit']
+                brightness_pps = row['brightness_integrated']
                 brightness_kpps = brightness_pps / 1000.0
 
                 radius_px = 3 * max(row['sigx_fit'], row['sigy_fit']) / pix_size_um
@@ -185,7 +185,7 @@ def plot_monomer_brightness(
         xs = df['x_pix'].to_numpy()
         ys = df['y_pix'].to_numpy()
         rs = (3 * np.maximum(df['sigx_fit'].to_numpy(), df['sigy_fit'].to_numpy()) / pix_size_um).astype(float)
-        br = df['brightness_fit'].to_numpy()
+        br = df['brightness_integrated'].to_numpy()
         br_k = (br / 1000.0).astype(float)
         cats = np.where(br < t1, 'Monomers', np.where(br < t2, 'Dimers', np.where(br < t3, 'Trimers', 'Multimers')))
         colors = [CATEGORY_COLORS[c] for c in cats]
@@ -424,7 +424,7 @@ def run():
         with plot_col2:
             if not combined_df.empty:
                 # Get defaults
-                brightness_vals = combined_df['brightness_fit'].values
+                brightness_vals = combined_df['brightness_integrated'].values
                 default_min_val = float(np.min(brightness_vals))
                 default_max_val = float(np.max(brightness_vals))
                 
@@ -474,7 +474,7 @@ def run():
                             st.warning(f"Label/bin mismatch: {len(labels_for_pie)} labels for {num_bins_pie} bins.")
                         else:
                             categories = pd.cut(
-                                combined_df['brightness_fit'],
+                                combined_df['brightness_integrated'],
                                 bins=bins_for_pie,
                                 right=False,
                                 include_lowest=True,

--- a/tools/plot_csv.py
+++ b/tools/plot_csv.py
@@ -1,6 +1,7 @@
 
 import io
 import json
+import os
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -54,6 +55,12 @@ def run():
       smooth_window = st.slider("Rolling window size", 3, 101, 9, step=2)
       group_agg = st.selectbox("If multiple rows per group, aggregate Y using:", ["None", "mean", "median"])
       download_cleaned = st.checkbox("Enable download of cleaned/reshaped data", value=True)
+
+  if uploaded is not None:
+      selected_file_name = uploaded.name
+  else:
+      selected_file_name = "example_data.csv" if use_example else "plotted_data.csv"
+  selected_file_stem = os.path.splitext(selected_file_name)[0]
   
   # Helper palettes
   PLOTLY_PALETTES = {
@@ -272,7 +279,12 @@ def run():
   
       if download_cleaned:
           csv = long_df.to_csv(index=False).encode("utf-8")
-          st.download_button("⬇️ Download plotted data (CSV)", data=csv, file_name="plotted_data.csv", mime="text/csv")
+          st.download_button(
+              "⬇️ Download plotted data (CSV)",
+              data=csv,
+              file_name=f"{selected_file_stem}_plotted_data.csv",
+              mime="text/csv",
+          )
   
   def draw_paired_plot(tidy: pd.DataFrame):
       if tidy.empty:
@@ -310,7 +322,12 @@ def run():
   
       if download_cleaned:
           csv = plot_df.to_csv(index=False).encode("utf-8")
-          st.download_button("⬇️ Download plotted data (CSV)", data=csv, file_name="plotted_data_paired.csv", mime="text/csv")
+          st.download_button(
+              "⬇️ Download plotted data (CSV)",
+              data=csv,
+              file_name=f"{selected_file_stem}_plotted_data_paired.csv",
+              mime="text/csv",
+          )
   
   # Load data
   if uploaded is not None:

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -592,7 +592,7 @@ def segment_and_measure_shapes(
 
     # Binary image and watershed segmentation
     smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    soft_threshold = threshold + 200 #trial bias to soften
+    soft_threshold = threshold - 200 #trial bias to soften
     im_bi = smoothed < soft_threshold
     im_bi = binary_closing(im_bi, disk(2))
     im_bi = binary_opening(im_bi, disk(1))

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -25,7 +25,7 @@ import os
 import tempfile
 import datetime as dt
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -63,6 +63,214 @@ class DM3Image:
 
 
 # ---------------------------------------------------------------------------
+# Metadata helpers
+# ---------------------------------------------------------------------------
+
+
+UNIT_TO_NM: Dict[str, float] = {
+    "m": 1e9,
+    "meter": 1e9,
+    "metre": 1e9,
+    "mm": 1e6,
+    "millimeter": 1e6,
+    "millimetre": 1e6,
+    "um": 1e3,
+    "micrometer": 1e3,
+    "micrometre": 1e3,
+    "micron": 1e3,
+    "µm": 1e3,
+    "pm": 1e-3,
+    "picometer": 1e-3,
+    "picometre": 1e-3,
+    "nm": 1.0,
+    "nanometer": 1.0,
+    "nanometre": 1.0,
+    "angstrom": 0.1,
+    "angstroem": 0.1,
+    "ang": 0.1,
+    "a": 0.1,
+}
+
+
+def _normalize_unit(unit: Any) -> Optional[str]:
+    """Normalize unit strings for lookup in :data:`UNIT_TO_NM`."""
+
+    if unit is None:
+        return None
+    if isinstance(unit, bytes):
+        try:
+            unit = unit.decode("utf-8")
+        except Exception:  # pragma: no cover - best effort decoding
+            unit = unit.decode("latin1", errors="ignore")
+    unit_str = str(unit).strip().lower()
+    if not unit_str:
+        return None
+    replacements = (
+        ("µ", "u"),
+        ("μ", "u"),
+        ("ångström", "angstrom"),
+        ("angström", "angstrom"),
+        ("meters", "meter"),
+        ("metres", "metre"),
+        ("nanometers", "nanometer"),
+        ("nanometres", "nanometre"),
+        ("micrometers", "micrometer"),
+        ("micrometres", "micrometre"),
+        ("millimeters", "millimeter"),
+        ("millimetres", "millimetre"),
+        ("microns", "micron"),
+    )
+    for old, new in replacements:
+        unit_str = unit_str.replace(old, new)
+    for suffix in ("/pixel", " per pixel", "per pixel", "/px", " perpix", "perpix"):
+        if suffix in unit_str:
+            unit_str = unit_str.replace(suffix, "")
+    unit_str = unit_str.replace("pixel", "")
+    unit_str = unit_str.replace(" per", "")
+    unit_str = unit_str.strip()
+    if unit_str.endswith("s") and unit_str not in {"ms"}:
+        unit_str = unit_str[:-1]
+    return unit_str or None
+
+
+def _factor_from_unit(unit: Any) -> Optional[float]:
+    cleaned = _normalize_unit(unit)
+    if not cleaned or "/" in cleaned:
+        return None
+    return UNIT_TO_NM.get(cleaned)
+
+
+def _convert_scale_value(value: Any, unit: Any = None, default_factor: Optional[float] = None) -> Optional[float]:
+    """Convert calibration values to nm/pixel if possible."""
+
+    if isinstance(value, dict):
+        unit_candidates = [
+            value.get("unit"),
+            value.get("units"),
+            value.get("Unit"),
+            value.get("Units"),
+        ]
+        unit_pref = next((u for u in unit_candidates if u is not None), unit)
+        value_candidates = [
+            value.get("value"),
+            value.get("Value"),
+            value.get("scale"),
+            value.get("Scale"),
+        ]
+        for candidate in value_candidates:
+            nm = _convert_scale_value(candidate, unit=unit_pref, default_factor=default_factor)
+            if nm is not None:
+                return nm
+        for sub_value in value.values():
+            nm = _convert_scale_value(sub_value, unit=unit, default_factor=default_factor)
+            if nm is not None:
+                return nm
+        return None
+
+    if hasattr(value, "value"):
+        attr_unit = getattr(value, "unit", None) or getattr(value, "units", None)
+        nm = _convert_scale_value(value.value, unit=attr_unit or unit, default_factor=default_factor)
+        if nm is not None:
+            return nm
+
+    if isinstance(value, (list, tuple, np.ndarray)):
+        arr = np.array(value, dtype=object).ravel()
+        for item in arr:
+            nm = _convert_scale_value(item, unit=unit, default_factor=default_factor)
+            if nm is not None:
+                return nm
+        return None
+
+    try:
+        val_float = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(val_float) or val_float <= 0:
+        return None
+
+    factor = _factor_from_unit(unit)
+    if factor is None:
+        factor = default_factor
+    if factor is None:
+        return None
+    return val_float * factor
+
+
+def _flatten_to_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        out: List[Any] = []
+        for item in value:
+            out.extend(_flatten_to_list(item))
+        return out
+    return [value]
+
+
+def _extract_from_pixel_info(pixel_size: Any, pixel_unit: Any) -> Optional[float]:
+    sizes = _flatten_to_list(pixel_size)
+    if not sizes:
+        return None
+    units = _flatten_to_list(pixel_unit)
+    for idx, size in enumerate(sizes):
+        unit = units[idx] if idx < len(units) else (units[-1] if units else None)
+        nm = _convert_scale_value(size, unit=unit)
+        if nm is not None:
+            return nm
+    return None
+
+
+def _get_nested(metadata: Dict[str, Any], path: str) -> Any:
+    current: Any = metadata
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part in current:
+                current = current[part]
+                continue
+            if part.isdigit():
+                idx = int(part)
+                if idx in current:
+                    current = current[idx]
+                    continue
+            return None
+        elif isinstance(current, (list, tuple)):
+            if not part.isdigit():
+                return None
+            idx = int(part)
+            if idx >= len(current):
+                return None
+            current = current[idx]
+        else:
+            return None
+    return current
+
+
+def _search_scale_in_metadata(metadata: Any) -> Optional[float]:
+    tokens = ("pixel", "scale", "calibration", "dimension", "step", "size")
+
+    if isinstance(metadata, dict):
+        for key, value in metadata.items():
+            key_lower = str(key).lower()
+            default_factor = 1e9 if any(tok in key_lower for tok in ("scale", "calibration", "dimension")) else None
+            if any(tok in key_lower for tok in tokens):
+                nm = _convert_scale_value(value, default_factor=default_factor)
+                if nm is not None:
+                    return nm
+            nm = _search_scale_in_metadata(value)
+            if nm is not None:
+                return nm
+    elif isinstance(metadata, (list, tuple)):
+        for item in metadata:
+            nm = _search_scale_in_metadata(item)
+            if nm is not None:
+                return nm
+    return None
+
+
+# ---------------------------------------------------------------------------
 # File handling utilities
 # ---------------------------------------------------------------------------
 
@@ -83,27 +291,38 @@ def try_read_dm3(file_bytes: bytes) -> DM3Image:
             im = rdr.getDataset(0)
             data = np.array(im["data"], dtype=np.float32)
 
-            nm_per_px = np.nan
+            nm_per_px = float("nan")
             md = rdr.allTags
-            candidates = [
-                ("ImageList.1.ImageData.Calibrations.Dimension.0.Scale", 1e9),
-                ("ImageList.1.ImageData.Calibrations.Dimension.1.Scale", 1e9),
-                ("pixelSize.x", 1e9),
-                ("pixelSize", 1e9),
-                ("xscale", 1e9),
-                ("ImageList.2.ImageData.Calibrations.Dimension.0.Scale", 1e9),
-                ("ImageList.2.ImageData.Calibrations.Dimension.1.Scale", 1e9),
-            ]
-            for key, factor in candidates:
-                try:
-                    val = md
-                    for k in key.split("."):
-                        val = val[k]
-                    if isinstance(val, (int, float)):
-                        nm_per_px = float(val) * factor
+
+            nm_from_dataset = _extract_from_pixel_info(im.get("pixelSize"), im.get("pixelUnit"))
+            if nm_from_dataset is not None:
+                nm_per_px = nm_from_dataset
+
+            if not np.isfinite(nm_per_px):
+                candidates = [
+                    "ImageList.1.ImageData.Calibrations.Dimension.0.Scale",
+                    "ImageList.1.ImageData.Calibrations.Dimension.1.Scale",
+                    "ImageList.0.ImageData.Calibrations.Dimension.0.Scale",
+                    "ImageList.0.ImageData.Calibrations.Dimension.1.Scale",
+                    "ImageList.2.ImageData.Calibrations.Dimension.0.Scale",
+                    "ImageList.2.ImageData.Calibrations.Dimension.1.Scale",
+                    "pixelSize.x",
+                    "pixelSize",
+                    "xscale",
+                ]
+                for key in candidates:
+                    raw_val = _get_nested(md, key)
+                    if raw_val is None:
+                        continue
+                    nm_candidate = _convert_scale_value(raw_val, default_factor=1e9)
+                    if nm_candidate is not None:
+                        nm_per_px = nm_candidate
                         break
-                except Exception:
-                    continue
+
+            if not np.isfinite(nm_per_px):
+                nm_meta = _search_scale_in_metadata(md)
+                if nm_meta is not None:
+                    nm_per_px = nm_meta
 
         return DM3Image(data=data, nm_per_px=nm_per_px)
     finally:  # pragma: no cover - best effort cleanup
@@ -229,8 +448,12 @@ def segment_and_measure_shapes(
         exclusion_zone_px = 0.0
     img_h, img_w = data.shape
 
-    fig, ax = plt.subplots()
-    ax.imshow(data, cmap="gray")
+    aspect_ratio = img_w / img_h if img_h else 1.0
+    base_height = 4.0
+    fig_width = float(np.clip(base_height * aspect_ratio, 3.0, 7.5))
+
+    fig, ax = plt.subplots(figsize=(fig_width, base_height), dpi=200)
+    ax.imshow(data, cmap="gray", interpolation="nearest")
     ax.axis("off")
 
     for p in regionprops(labels_ws):
@@ -301,14 +524,14 @@ def segment_and_measure_shapes(
                     ax.add_patch(circ_patch)
 
     buf_ann = io.BytesIO()
-    fig.savefig(buf_ann, format="png", bbox_inches="tight", pad_inches=0)
+    fig.savefig(buf_ann, format="png", bbox_inches="tight", pad_inches=0, dpi=200)
     plt.close(fig)
 
-    fig_ws, ax_ws = plt.subplots()
-    ax_ws.imshow(labels_ws, cmap="gray")
+    fig_ws, ax_ws = plt.subplots(figsize=(fig_width, base_height), dpi=200)
+    ax_ws.imshow(labels_ws, cmap="gray", interpolation="nearest")
     ax_ws.axis("off")
     buf_ws = io.BytesIO()
-    fig_ws.savefig(buf_ws, format="png", bbox_inches="tight", pad_inches=0)
+    fig_ws.savefig(buf_ws, format="png", bbox_inches="tight", pad_inches=0, dpi=200)
     plt.close(fig_ws)
 
     out: Dict[str, np.ndarray] = {
@@ -318,6 +541,7 @@ def segment_and_measure_shapes(
         "widths_nm": np.array(widths_nm, dtype=np.float32),
         "annotated_png": buf_ann.getvalue(),
         "watershed_png": buf_ws.getvalue(),
+        "image_shape": (int(img_h), int(img_w)),
     }
 
     # For cubic particles we treat height equal to width (2‑D approximation)
@@ -482,11 +706,31 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
             sel_name = st.selectbox("Select image to display", names)
             sel = next(r for r in results if r["name"] == sel_name)
 
+            shape = sel.get("image_shape") if isinstance(sel, dict) else None
+            if shape and len(shape) == 2:
+                try:
+                    width_px = int(shape[1])
+                except Exception:
+                    width_px = 0
+            else:
+                width_px = 0
+            display_width = max(320, min(900, width_px // 2)) if width_px > 0 else 600
+
             tab1, tab2 = st.tabs(["Annotated", "Watershed"])
             with tab1:
-                st.image(sel["annotated_png"], caption=f"Annotated segmentation preview ({sel['unit']})", use_column_width=True)
+                st.image(
+                    sel["annotated_png"],
+                    caption=f"Annotated segmentation preview ({sel['unit']})",
+                    width=display_width,
+                    use_container_width=False,
+                )
             with tab2:
-                st.image(sel["watershed_png"], caption="Watershed labels", use_column_width=True)
+                st.image(
+                    sel["watershed_png"],
+                    caption="Watershed labels",
+                    width=display_width,
+                    use_container_width=False,
+                )
 
         if missing_scale_files:
             missing_list = "\n".join(f"• {name}" for name in sorted(set(missing_scale_files)))

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -44,6 +44,7 @@ from skimage import morphology as morph
 from skimage import segmentation as seg
 from skimage.measure import label
 from skimage.filters import gaussian
+from scipy.ndimage import distance_transform_edt
 
 
 

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -624,7 +624,7 @@ def segment_and_measure_shapes(
         im_complement = 1.0 - im_norm
         im_complement = ndi.gaussian_filter(im_complement, sigma=1.0)
 
-        watershed_labels = seg.watershed(im_complement)
+        watershed_labels = seg.watershed(im_complement, watershed_line=True)
         ridge_mask = watershed_labels == 0
 
         im_split = im_bi.copy()

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -592,7 +592,8 @@ def segment_and_measure_shapes(
 
     # Binary image and watershed segmentation
     smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    im_bi = smoothed < threshold
+    soft_threshold = threshold + 200 #trial bias to soften
+    im_bi = smoothed < soft_threshold
     im_bi = binary_closing(im_bi, disk(2))
     im_bi = binary_opening(im_bi, disk(1))
     hole_area = max(int(min_area_px * 4), 16)

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -45,6 +45,7 @@ from skimage import segmentation as seg
 from skimage.measure import label
 from skimage.filters import gaussian
 from scipy.ndimage import distance_transform_edt
+from skimage.feature import peak_local_max
 
 
 

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -43,6 +43,8 @@ from scipy import ndimage as ndi
 from skimage import morphology as morph
 from skimage import segmentation as seg
 from skimage.measure import label
+from skimage.filters import gaussian
+
 
 
 SESSION_CACHE_KEY = "_tem_size_cache"

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -601,6 +601,8 @@ def segment_and_measure_shapes(
     im_bi = data < threshold
     im_bi = morph.binary_closing(im_bi, morph.disk(3))
     im_bi = morph.remove_small_objects(im_bi, min_size=max(min_area_px, 32))
+    hole_area = max(int(min_area_px * 4), 16)
+
 
     if np.any(im_bi):
         distance_map = ndi.distance_transform_edt(im_bi)

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -50,6 +50,7 @@ from sklearn.mixture import GaussianMixture
 
 
 SESSION_CACHE_KEY = "_tem_size_cache"
+BASE_CACHE_KEY = "_tem_gmm_base_cache"
 
 PLOTLY_SHAPE_CONFIG = {"displaylogo": False}
 

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -592,8 +592,7 @@ def segment_and_measure_shapes(
 
     # Binary image and watershed segmentation
     smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    soft_threshold = threshold  #trial bias to soften
-    im_bi = smoothed > soft_threshold
+    im_bi = smoothed < threshold
     im_bi = binary_closing(im_bi, disk(2))
     im_bi = binary_opening(im_bi, disk(1))
     hole_area = max(int(min_area_px * 4), 16)

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -592,8 +592,8 @@ def segment_and_measure_shapes(
 
     # Binary image and watershed segmentation
     smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    soft_threshold = threshold - 200 #trial bias to soften
-    im_bi = smoothed < soft_threshold
+    soft_threshold = threshold  #trial bias to soften
+    im_bi = smoothed > soft_threshold
     im_bi = binary_closing(im_bi, disk(2))
     im_bi = binary_opening(im_bi, disk(1))
     hole_area = max(int(min_area_px * 4), 16)

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -618,7 +618,7 @@ def segment_and_measure_shapes(
         im_bi_split[labels_ws == 0] = False
         im_bi_filtered = morph.remove_small_objects(
             im_bi_split,
-            min_size=max(min_area_px, 5000),
+            min_size=min_area_px,
         )
         im_bi_filtered = morph.remove_small_holes(
             im_bi_filtered,

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -20,12 +20,13 @@ Streamlit workflow.
 from __future__ import annotations
 
 import io
+import json
 import math
 import os
 import tempfile
 import datetime as dt
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Dict, List, Tuple, Optional, Any, Iterable
 
 import matplotlib.pyplot as plt
@@ -40,27 +41,22 @@ from skimage import segmentation as seg
 from skimage.measure import label, regionprops
 from sklearn.mixture import GaussianMixture
 
-from scipy import ndimage as ndi
-from skimage import morphology as morph
-from skimage import segmentation as seg
-from skimage.measure import label
-from skimage.filters import gaussian
-from scipy.ndimage import distance_transform_edt
-from skimage.feature import peak_local_max
-
-from skimage.morphology import (
-    remove_small_objects,
-    remove_small_holes,
-    binary_closing,
-    binary_opening,
-    disk,
-)
-
 
 SESSION_CACHE_KEY = "_tem_size_cache"
 BASE_CACHE_KEY = "_tem_gmm_base_cache"
 
-PLOTLY_SHAPE_CONFIG = {"displaylogo": False}
+PLOTLY_SHAPE_CONFIG = {
+    "displaylogo": False,
+    "scrollZoom": False,
+    "modeBarButtonsToRemove": [
+        "zoom3d",
+        "pan3d",
+        "resetCameraDefault3d",
+        "resetCameraLastSave3d",
+        "zoomIn3d",
+        "zoomOut3d",
+    ],
+}
 
 # Optional import of ncempy (for reading dm3 files)
 try:  # pragma: no cover - simply a convenience check
@@ -87,6 +83,23 @@ class PreprocessedImage:
     threshold: float
     nm_per_px: float
     measurement_unit: str
+
+
+@dataclass(frozen=True)
+class SegmentationTuning:
+    threshold_scale: float = 1.0
+    threshold_offset: float = 0.0
+    closing_radius: int = 3
+    opening_radius: int = 0
+    pre_min_area_px: int = 32
+    pre_hole_area_px: int = 256
+    post_min_area_px: int = 32
+    post_hole_area_px: int = 512
+    distance_sigma: float = 1.0
+    h_maxima: float = 2.0
+    background_sigma: float = 0.0
+    background_strength: float = 1.0
+    watershed_gradient_sigma: float = 15.0
 
 
 # ---------------------------------------------------------------------------
@@ -565,6 +578,31 @@ def _is_rectangle(
     return False
 
 
+
+
+def prepare_watershed_display(labels: np.ndarray, sigma: float) -> np.ndarray:
+    ws_float = np.asarray(labels, dtype=np.float32)
+    if ws_float.size == 0:
+        return ws_float
+
+    if sigma > 0.0:
+        ws_float = ws_float - ndi.gaussian_filter(ws_float, sigma=float(sigma))
+
+    min_val = float(ws_float.min())
+    ws_float = ws_float - min_val
+    max_val = float(ws_float.max())
+    if max_val > 0:
+        ws_float = ws_float / max_val
+    else:
+        ws_float.fill(0.0)
+
+    boundaries = seg.find_boundaries(labels, mode="outer")
+    if np.any(boundaries):
+        ws_float[boundaries] = 1.0
+
+    return ws_float
+
+
 def segment_and_measure_shapes(
     data: np.ndarray,
     threshold: float,
@@ -573,6 +611,7 @@ def segment_and_measure_shapes(
     min_size_value: float,
     measurement_unit: str,
     min_area_px: int = 5,
+    tuning: Optional[SegmentationTuning] = None,
 ) -> Dict[str, np.ndarray]:
     """Segment particles and measure their dimensions.
 
@@ -581,7 +620,7 @@ def segment_and_measure_shapes(
     data: ndarray
         The image data.
     threshold: float
-        Threshold value for creating a binary mask.
+        Baseline threshold value for creating a binary mask.
     nm_per_px: float
         Pixel to nanometre scaling.
     shape_type: str
@@ -592,11 +631,16 @@ def segment_and_measure_shapes(
         Unit label for size measurements (``"nm"`` or ``"px"``).
     min_area_px: int
         Minimum area (in pixels) for removing small objects.
+    tuning: SegmentationTuning, optional
+        Interactive tuning parameters selected by the user.
 
     Returns
     -------
     Dict with measurement arrays and PNG overlays.
     """
+
+    if tuning is None:
+        tuning = SegmentationTuning()
 
     if measurement_unit == "nm" and np.isfinite(nm_per_px) and nm_per_px > 0:
         scale_factor = nm_per_px
@@ -605,149 +649,92 @@ def segment_and_measure_shapes(
         scale_factor = 1.0
         exclusion_zone_px = 0.0
 
-    area_keep_threshold = max(int(min_area_px), 3)
-    hole_area_threshold = max(int(4 * min_area_px), 32)
+    data_float = np.asarray(data, dtype=np.float32)
+    seg_data = np.array(data_float, copy=True)
 
-    # Binary image and watershed segmentation following the MATLAB reference
-    im_bi = data < threshold
-    im_bi = morph.binary_closing(im_bi, morph.disk(3))
-    im_bi = morph.remove_small_holes(im_bi, area_threshold=hole_area_threshold)
-
-    if np.any(im_bi):
-        data_float = data.astype(np.float32)
-        data_min = float(np.min(data_float))
-        data_max = float(np.max(data_float))
-        if data_max > data_min:
-            im_norm = (data_float - data_min) / (data_max - data_min)
-        else:
-            im_norm = np.zeros_like(data_float)
-        im_complement = 1.0 - im_norm
-        im_complement = ndi.gaussian_filter(im_complement, sigma=1.0)
-
-        watershed_labels = seg.watershed(im_complement, watershed_line=True)
-        ridge_mask = watershed_labels == 0
-
-        im_split = im_bi.copy()
-        im_split[ridge_mask] = False
-        im_split = morph.remove_small_objects(
-            im_split,
-            min_size=area_keep_threshold,
+    if tuning.background_sigma > 0.0 and tuning.background_strength != 0.0:
+        seg_data = seg_data - float(tuning.background_strength) * ndi.gaussian_filter(
+            seg_data, sigma=float(tuning.background_sigma)
         )
-        im_split = morph.remove_small_holes(
-            im_split,
-            area_threshold=hole_area_threshold,
-        )
-        labels_ws = label(im_split)
-        im_bi = im_split
 
-    # Binary image and watershed segmentation
-    im_bi = data < threshold
-    im_bi = morph.binary_closing(im_bi, morph.disk(3))
-    im_bi = morph.remove_small_objects(im_bi, min_size=max(min_area_px, 32))
-    hole_area = max(int(min_area_px * 4), 16)
+    threshold_used = float(threshold) if np.isfinite(threshold) else 0.0
+    threshold_used = threshold_used * float(tuning.threshold_scale) + float(tuning.threshold_offset)
 
+    finite_seg = seg_data[np.isfinite(seg_data)]
+    offset = float(finite_seg.min()) if finite_seg.size else 0.0
+    seg_data = seg_data - offset
+    threshold_used -= offset
 
-    if np.any(im_bi):
-        distance_map = ndi.distance_transform_edt(im_bi)
-        distance_smooth = ndi.gaussian_filter(distance_map, sigma=1.0)
-        h_val = 2
-        markers_bin = morph.h_maxima(distance_smooth, h=h_val)
-        markers = label(markers_bin)
-        if markers.max() == 0:
-            markers = label(im_bi)
+    base_threshold_adj = (float(threshold) - offset) if np.isfinite(threshold) else float("nan")
 
-        labels_ws = seg.watershed(-distance_smooth, markers=markers, mask=im_bi)
-        im_bi_split = im_bi.copy()
-        im_bi_split[labels_ws == 0] = False
-        im_bi_filtered = morph.remove_small_objects(
-            im_bi_split,
-            min_size=min_area_px,
-        )
-        im_bi_filtered = morph.remove_small_holes(
-            im_bi_filtered,
-            area_threshold=max(4 * min_area_px, 256),
-        )
-        labels_ws = label(im_bi_filtered)
-        im_bi = im_bi_filtered
-    smoothed = gaussian(data.astype(np.float32), sigma=0.8, preserve_range=True)
-    # im_bi = smoothed < threshold
-    # im_bi = binary_closing(im_bi, disk(2))
-    # im_bi = binary_opening(im_bi, disk(1))
-    # hole_area = max(int(min_area_px * 4), 16)
-    # im_bi = remove_small_holes(im_bi, area_threshold=hole_area)
-    # im_bi = im_bi.astype(bool)
-
-    im_bi = (data < threshold)
-    im_bi = morph.binary_closing(im_bi, morph.disk(3))
-    im_bi = morph.remove_small_objects(im_bi, min_size=max(min_area_px, 32))
-
-
-
-
-    
-
-    if np.any(im_bi):
-        dist = distance_transform_edt(im_bi)
-        smoothed_dist = gaussian(dist, sigma=1.0, preserve_range=True)
-        h_val = 2  # try 1–3; increase if over-seg, decrease if under-seg
-        markers_bin = morph.h_maxima(smoothed_dist, h=h_val)
-        markers = label(markers_bin)
-        labels_ws = seg.watershed(-smoothed_dist, markers=markers, mask=im_bi)
-        im_bi_split = im_bi.copy()
-        im_bi_split[labels_ws == 0] = False
-        im_bi_filtered = morph.remove_small_objects(im_bi_split, min_size=max(min_area_px, 5000))
-        im_bi_filtered = morph.remove_small_holes(im_bi_filtered, area_threshold=max(4*min_area_px, 256))
-        labels_ws = label(im_bi_filtered)
-
-
-        
-        component_labels = label(im_bi)
-        local_max = peak_local_max(
-            smoothed_dist,
-            footprint=np.ones((3, 3), dtype=bool),
-            labels=im_bi,
-            threshold_abs=0.0,
-            exclude_border=False,
-        )
-        if local_max.size == 0:
-            markers = component_labels
-        else:
-            marker_mask = np.zeros_like(im_bi, dtype=bool)
-            marker_mask[tuple(local_max.T)] = True
-            markers = label(marker_mask)
-
-            component_count = int(component_labels.max())
-            if component_count > 0:
-                has_marker = np.zeros(component_count + 1, dtype=bool)
-                if np.any(marker_mask):
-                    has_marker[component_labels[marker_mask]] = True
-                missing_components = np.where(~has_marker)[0]
-                missing_components = missing_components[missing_components > 0]
-                if missing_components.size:
-                    current_max = int(markers.max())
-                    for comp_id in missing_components:
-                        comp_mask = component_labels == comp_id
-                        if not np.any(comp_mask):
-                            continue
-                        rows, cols = np.where(comp_mask)
-                        if rows.size == 0:
-                            continue
-                        comp_dist = dist[comp_mask]
-                        if comp_dist.size == 0:
-                            continue
-                        max_idx = int(np.argmax(comp_dist))
-                        current_max += 1
-                        markers[rows[max_idx], cols[max_idx]] = current_max
-
-        refined_mask = labels_ws > 0
-        refined_mask = remove_small_objects(refined_mask, min_size=max(min_area_px, 3))
-        refined_mask = remove_small_holes(refined_mask, area_threshold=hole_area)
-        labels_ws = label(refined_mask)
-        im_bi = refined_mask
+    finite_seg = seg_data[np.isfinite(seg_data)]
+    if finite_seg.size:
+        seg_min = float(finite_seg.min())
+        seg_max = float(finite_seg.max())
     else:
-        labels_ws = np.zeros_like(data, dtype=np.int32)
+        seg_min = 0.0
+        seg_max = 0.0
 
-    # Prepare measurement containers
+    if seg_max > seg_min:
+        threshold_used = float(np.clip(threshold_used, seg_min, seg_max))
+    else:
+        threshold_used = float(seg_min)
+
+    mask = seg_data < threshold_used
+    mask = np.asarray(mask, dtype=bool)
+
+    closing_radius = max(int(tuning.closing_radius), 0)
+    if closing_radius > 0:
+        mask = morph.binary_closing(mask, morph.disk(closing_radius))
+
+    opening_radius = max(int(tuning.opening_radius), 0)
+    if opening_radius > 0:
+        mask = morph.binary_opening(mask, morph.disk(opening_radius))
+
+    base_min_area = max(int(min_area_px), 1)
+    pre_min_area = max(int(tuning.pre_min_area_px), base_min_area)
+    if pre_min_area > 1:
+        mask = morph.remove_small_objects(mask, min_size=pre_min_area)
+
+    pre_hole_area = max(int(tuning.pre_hole_area_px), 1)
+    if pre_hole_area > 0:
+        mask = morph.remove_small_holes(mask, area_threshold=pre_hole_area)
+
+    labels_ws = np.zeros_like(mask, dtype=np.int32)
+    refined_mask = mask.copy()
+
+    if np.any(mask):
+        distance_map = ndi.distance_transform_edt(mask)
+        if tuning.distance_sigma > 0.0:
+            distance_smooth = ndi.gaussian_filter(distance_map, sigma=float(tuning.distance_sigma))
+        else:
+            distance_smooth = distance_map
+
+        markers = None
+        if tuning.h_maxima > 0.0:
+            markers_bin = morph.h_maxima(distance_smooth, h=float(tuning.h_maxima))
+            if np.any(markers_bin):
+                markers = label(markers_bin)
+
+        if markers is None or markers.max() == 0:
+            markers = label(mask)
+
+        labels_ws = seg.watershed(-distance_smooth, markers=markers, mask=mask)
+        refined_mask = labels_ws > 0
+
+        post_min_area = max(int(tuning.post_min_area_px), base_min_area)
+        if post_min_area > 1:
+            refined_mask = morph.remove_small_objects(refined_mask, min_size=post_min_area)
+
+        post_hole_area = max(int(tuning.post_hole_area_px), 1)
+        if post_hole_area > 0:
+            refined_mask = morph.remove_small_holes(refined_mask, area_threshold=post_hole_area)
+
+        labels_ws = label(refined_mask)
+    else:
+        refined_mask = mask.astype(bool, copy=False)
+        labels_ws = np.zeros_like(mask, dtype=np.int32)
+
     diameters_nm: List[float] = []
     hex_axes_nm: List[float] = []
     lengths_nm: List[float] = []
@@ -840,7 +827,7 @@ def segment_and_measure_shapes(
         aspect = maj / minr_axis if minr_axis > 0 else 0.0
         extent = area / ((maxr - minr) * (maxc - minc)) if (maxr - minr) * (maxc - minc) > 0 else 0.0
         solidity = getattr(p, "solidity", 0.0)
-        cy, cx = p.centroid  # note: regionprops returns (row, col)
+        cy, cx = p.centroid
 
         if shape_type == "Sphere":
             diam_px = (maj + minr_axis) / 2
@@ -886,7 +873,6 @@ def segment_and_measure_shapes(
                     _draw_debug_circle(ax, cx, cy, max(diag_px, maj, minr_axis) / 2, "b")
             continue
 
-        # Cube / rectangular case
         if length_val < min_size_value or width_val < min_size_value:
             continue
 
@@ -923,7 +909,8 @@ def segment_and_measure_shapes(
     fig.savefig(buf_ann, format="png", bbox_inches="tight", pad_inches=0, dpi=200)
     plt.close(fig)
 
-    hist_vals = robust_percentile_cut(data, 99.5)
+    hist_source = np.asarray(seg_data, dtype=np.float32)
+    hist_vals = robust_percentile_cut(hist_source, 99.5)
     counts, edges = np.histogram(hist_vals, bins=128)
     centers = edges[:-1] + np.diff(edges) / 2 if len(edges) > 1 else np.array([])
     bar_width = float(edges[1] - edges[0]) if len(edges) > 1 else 1.0
@@ -938,12 +925,17 @@ def segment_and_measure_shapes(
             color="#888888",
             edgecolor="#444444",
         )
+    label_parts = [f"threshold={threshold_used:.3f}"]
+    if np.isfinite(base_threshold_adj) and not math.isclose(
+        base_threshold_adj, threshold_used, rel_tol=1e-6, abs_tol=1e-6
+    ):
+        label_parts.append(f"base={base_threshold_adj:.3f}")
     ax_hist.axvline(
-        threshold,
+        threshold_used,
         color="red",
         linestyle="--",
         linewidth=1.5,
-        label=f"GMM threshold = {threshold:.3f}",
+        label="Segmentation " + ", ".join(label_parts),
     )
     ax_hist.set_xlabel("Intensity (a.u.)")
     ax_hist.set_ylabel("Pixel count")
@@ -957,7 +949,8 @@ def segment_and_measure_shapes(
     plt.close(fig_hist)
 
     fig_ws, ax_ws = plt.subplots(figsize=(fig_width, base_height), dpi=200)
-    ax_ws.imshow(labels_ws, cmap="gray", interpolation="nearest")
+    ws_display = prepare_watershed_display(labels_ws, float(tuning.watershed_gradient_sigma))
+    ax_ws.imshow(ws_display, cmap="gray", interpolation="nearest")
     ax_ws.axis("off")
     buf_ws = io.BytesIO()
     fig_ws.savefig(buf_ws, format="png", bbox_inches="tight", pad_inches=0, dpi=200)
@@ -971,11 +964,15 @@ def segment_and_measure_shapes(
         "annotated_png": buf_ann.getvalue(),
         "watershed_png": buf_ws.getvalue(),
         "intensity_hist_png": buf_hist.getvalue(),
-        "gmm_threshold": float(threshold),
+        "gmm_threshold": float(threshold_used),
+        "base_threshold": float(threshold) if np.isfinite(threshold) else float("nan"),
+        "base_threshold_adjusted": float(base_threshold_adj)
+        if np.isfinite(base_threshold_adj)
+        else float("nan"),
         "image_shape": (int(img_h), int(img_w)),
+        "tuning": asdict(tuning),
     }
 
-    # For cubic particles we treat height equal to width (2‑D approximation)
     if shape_type == "Cube":
         out["heights_nm"] = np.array(widths_nm, dtype=np.float32)
 
@@ -1436,8 +1433,11 @@ def process_dm3_files(
     records: List[PreprocessedImage],
     shape_type: str,
     min_shape_size_input: float,
+    tuning: SegmentationTuning,
 ) -> List[Dict[str, np.ndarray]]:
-    """Segment cached payloads using stored GMM thresholds."""
+    """Segment cached payloads using stored GMM thresholds and tuning."""
+
+
 
     results: List[Dict[str, np.ndarray]] = []
     min_shape_size_value = float(min_shape_size_input)
@@ -1451,6 +1451,7 @@ def process_dm3_files(
             min_size_value=min_shape_size_value,
             measurement_unit=record.measurement_unit,
             min_area_px=5,
+            tuning=tuning,
         )
         seg["name"] = record.name
         results.append(seg)
@@ -1473,6 +1474,7 @@ def build_processing_key(
     file_key: str,
     shape_type: str,
     min_shape_size_input: float,
+    tuning: SegmentationTuning,
 ) -> str:
     """Return a stable hash describing the current processing inputs."""
 
@@ -1480,6 +1482,9 @@ def build_processing_key(
     hasher.update(file_key.encode("utf-8"))
     hasher.update(shape_type.encode("utf-8"))
     hasher.update(np.float64(min_shape_size_input).tobytes())
+    tuning_blob = json.dumps(asdict(tuning), sort_keys=True).encode("utf-8")
+    hasher.update(len(tuning_blob).to_bytes(8, "little"))
+    hasher.update(tuning_blob)
     return hasher.hexdigest()
 
 
@@ -1524,6 +1529,108 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
             f"{'standard error' if report_standard_error else 'standard deviation'} values."
         )
 
+
+    with st.expander("Advanced tuning controls", expanded=False):
+        st.caption(
+            "Temporary controls for experimenting with segmentation and watershed tuning."
+        )
+        col_tune_a, col_tune_b, col_tune_c = st.columns(3)
+        with col_tune_a:
+            threshold_scale = st.slider(
+                "Threshold scale", 0.1, 3.0, 1.0, 0.05, help="Multiply the GMM threshold."
+            )
+            threshold_offset = st.slider(
+                "Threshold offset", -0.5, 0.5, 0.0, 0.01, help="Additive adjustment to the threshold."
+            )
+            background_sigma = st.slider(
+                "Background sigma", 0.0, 200.0, 0.0, 5.0, help="Gaussian blur radius for background removal."
+            )
+            background_strength = st.slider(
+                "Background strength", 0.0, 2.0, 1.0, 0.05, help="Multiplier for the subtracted background."
+            )
+            ws_gradient_sigma = st.slider(
+                "Watershed gradient sigma",
+                0.0,
+                50.0,
+                15.0,
+                1.0,
+                help="High-pass filtering strength applied to the watershed preview.",
+            )
+        with col_tune_b:
+            closing_radius = st.slider(
+                "Closing radius (px)", 0, 10, 3, 1, help="Binary closing radius before watershed."
+            )
+            opening_radius = st.slider(
+                "Opening radius (px)", 0, 10, 0, 1, help="Binary opening radius before watershed."
+            )
+            distance_sigma = st.slider(
+                "Distance smoothing sigma",
+                0.0,
+                5.0,
+                1.0,
+                0.1,
+                help="Gaussian smoothing applied to the distance transform.",
+            )
+            h_maxima = st.slider(
+                "H-maxima prominence",
+                0.0,
+                10.0,
+                2.0,
+                0.1,
+                help="Controls marker extraction for watershed via h-maxima suppression.",
+            )
+        with col_tune_c:
+            pre_min_area = st.number_input(
+                "Pre-watershed min area (px)",
+                min_value=1,
+                max_value=50_000,
+                value=32,
+                step=1,
+                format="%d",
+            )
+            pre_hole_area = st.number_input(
+                "Pre-watershed hole area (px)",
+                min_value=1,
+                max_value=100_000,
+                value=256,
+                step=1,
+                format="%d",
+            )
+            post_min_area = st.number_input(
+                "Post-watershed min area (px)",
+                min_value=1,
+                max_value=50_000,
+                value=32,
+                step=1,
+                format="%d",
+            )
+            post_hole_area = st.number_input(
+                "Post-watershed hole area (px)",
+                min_value=1,
+                max_value=100_000,
+                value=512,
+                step=1,
+                format="%d",
+            )
+
+        tuning = SegmentationTuning(
+            threshold_scale=float(threshold_scale),
+            threshold_offset=float(threshold_offset),
+            closing_radius=int(closing_radius),
+            opening_radius=int(opening_radius),
+            pre_min_area_px=int(pre_min_area),
+            pre_hole_area_px=int(pre_hole_area),
+            post_min_area_px=int(post_min_area),
+            post_hole_area_px=int(post_hole_area),
+            distance_sigma=float(distance_sigma),
+            h_maxima=float(h_maxima),
+            background_sigma=float(background_sigma),
+            background_strength=float(background_strength),
+            watershed_gradient_sigma=float(ws_gradient_sigma),
+        )
+
+
+
     results: List[Dict[str, np.ndarray]] = []
 
     missing_scale_files: List[str] = []
@@ -1557,6 +1664,7 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
             file_key=file_key,
             shape_type=shape_type,
             min_shape_size_input=min_shape_size_value,
+            tuning=tuning,
         )
         cache_entry = st.session_state.get(SESSION_CACHE_KEY)
 
@@ -1568,6 +1676,7 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
                     records=records,
                     shape_type=shape_type,
                     min_shape_size_input=min_shape_size_value,
+                    tuning=tuning,
                 )
             st.session_state[SESSION_CACHE_KEY] = {
                 "key": processing_key,
@@ -1611,8 +1720,14 @@ def run() -> None:  # pragma: no cover - Streamlit entry point
             col_hist, col_ws = st.columns(2)
             with col_hist:
                 if hist_png:
+                    caption_parts: List[str] = []
                     if threshold_value is not None and np.isfinite(threshold_value):
-                        caption = f"Intensity histogram (threshold={threshold_value:.4f})"
+                        caption_parts.append(f"applied={float(threshold_value):.4f}")
+                    base_threshold_value = sel.get("base_threshold")
+                    if base_threshold_value is not None and np.isfinite(base_threshold_value):
+                        caption_parts.append(f"base={float(base_threshold_value):.4f}")
+                    if caption_parts:
+                        caption = f"Intensity histogram ({', '.join(caption_parts)})"
                     else:
                         caption = "Intensity histogram"
                     st.image(hist_png, caption=caption, use_container_width=True)

--- a/tools/spherical_tem.py
+++ b/tools/spherical_tem.py
@@ -47,6 +47,13 @@ from skimage.filters import gaussian
 from scipy.ndimage import distance_transform_edt
 from skimage.feature import peak_local_max
 
+from skimage.morphology import (
+    remove_small_objects,
+    remove_small_holes,
+    binary_closing,
+    binary_opening,
+    disk,
+)
 
 
 SESSION_CACHE_KEY = "_tem_size_cache"

--- a/utils.py
+++ b/utils.py
@@ -153,7 +153,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
             #     sig_threshold = max(sig_threshold, SIGMA_UB)  # keep post-filter consistent
             # else:
             #     sigma_ub = 0.5
-            sigma_ub = 0.5
+            sigma_ub = 0.4
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
             ub = [2 * amp_guess, x0_guess + 1, sigma_ub, y0_guess + 1, sigma_ub, offset_guess * 1.2]

--- a/utils.py
+++ b/utils.py
@@ -92,7 +92,8 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
     coords = [tuple(c) for c in coords]  # list of (y, x)
     results = []
     seen = set()  # to avoid infinite loops on duplicates
-    
+
+    i = 0
     while i < len(coords):
         center_y, center_x = coords[i]
         i += 1

--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def HWT_aesthetic():
     sns.despine()
     return palette 
 
-def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.8):
+def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.5):
     image_data, metadata = sif_parser.np_open(sif, ignore_corrupt=True)
     image_data = image_data[0]  # (H, W)
 

--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def HWT_aesthetic():
     sns.despine()
     return palette 
 
-def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.5):
+def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.3):
     image_data, metadata = sif_parser.np_open(sif, ignore_corrupt=True)
     image_data = image_data[0]  # (H, W)
 
@@ -148,7 +148,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
                 return model - z
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
-            ub = [2 * amp_guess, x0_guess + 1, 0.8, y0_guess + 1, 0.8, offset_guess * 1.2]
+            ub = [2 * amp_guess, x0_guess + 1, 0.5, y0_guess + 1, 0.5, offset_guess * 1.2]
 
             # Perform fit
             res = least_squares(residuals, p0, args=(x_flat, y_flat, z_flat), bounds=(lb, ub))

--- a/utils.py
+++ b/utils.py
@@ -147,12 +147,13 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
                 model = A * np.exp(-((x - x0)**2 / (2 * sx**2) + (y - y0)**2 / (2 * sy**2))) + offset
                 return model - z
 
-            region = str(region)
-            if region == '4':
-                sigma_ub = 0.8 #for wider NIR peaks
-                sig_threshold = max(sig_threshold, SIGMA_UB)  # keep post-filter consistent
-            else:
-                sigma_ub = 0.5
+            # region = str(region)
+            # if region == '4':
+            #     sigma_ub = 0.8 #for wider NIR peaks
+            #     sig_threshold = max(sig_threshold, SIGMA_UB)  # keep post-filter consistent
+            # else:
+            #     sigma_ub = 0.5
+            sigma_ub = 0.5
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
             ub = [2 * amp_guess, x0_guess + 1, sigma_ub, y0_guess + 1, sigma_ub, offset_guess * 1.2]

--- a/utils.py
+++ b/utils.py
@@ -153,7 +153,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
             #     sig_threshold = max(sig_threshold, SIGMA_UB)  # keep post-filter consistent
             # else:
             #     sigma_ub = 0.5
-            sigma_ub = 0.4
+            sigma_ub = 0.3
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
             ub = [2 * amp_guess, x0_guess + 1, sigma_ub, y0_guess + 1, sigma_ub, offset_guess * 1.2]

--- a/utils.py
+++ b/utils.py
@@ -177,8 +177,9 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um=0.1
         if cached_result is _SKIP_RESULT:
             continue
         if cached_result is not None:
-            results.append(cached_result.copy())
-            continue
+            # A prior candidate already fit this PSF; skip duplicating it.
+
+            results.append(cached_result.copy
 
         # Extract finer subregion
         sub_img_fine, x0_idx_fine, y0_idx_fine = extract_subregion(

--- a/utils.py
+++ b/utils.py
@@ -179,7 +179,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um=0.1
         if cached_result is not None:
             # A prior candidate already fit this PSF; skip duplicating it.
 
-            results.append(cached_result.copy
+            results.append(cached_result.copy)
 
         # Extract finer subregion
         sub_img_fine, x0_idx_fine, y0_idx_fine = extract_subregion(

--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def HWT_aesthetic():
     sns.despine()
     return palette 
 
-def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.6):
+def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0.1, sig_threshold = 0.8):
     image_data, metadata = sif_parser.np_open(sif, ignore_corrupt=True)
     image_data = image_data[0]  # (H, W)
 

--- a/utils.py
+++ b/utils.py
@@ -82,7 +82,8 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
     if signal == 'UCNP':
         coords = peak_local_max(smoothed_image, min_distance=suppression_radius, 
                                 threshold_abs=threshold_abs,         
-                                footprint=np.ones((3, 3))      # tighter NMS)
+                                footprint=np.ones((3, 3))      # tighter NMS 
+                               )
     else:
         blobs = blob_log(smoothed_image, min_sigma=0.8, max_sigma=3, num_sigma=5, threshold=5 * threshold)
         coords = blobs[:, :2]

--- a/utils.py
+++ b/utils.py
@@ -180,6 +180,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um=0.1
             # A prior candidate already fit this PSF; skip duplicating it.
 
             results.append(cached_result.copy)
+            continue
 
         # Extract finer subregion
         sub_img_fine, x0_idx_fine, y0_idx_fine = extract_subregion(

--- a/utils.py
+++ b/utils.py
@@ -288,7 +288,7 @@ def integrate_sif(
 
         # Fit
         try:
-            sigma_ub = 0.3
+            sigma_ub = 0.3 * pix_size_um
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
             ub = [2 * amp_guess, x0_guess + 1, sigma_ub, y0_guess + 1, sigma_ub, offset_guess * 1.2]
@@ -307,6 +307,7 @@ def integrate_sif(
                 fit_cache[cache_key] = _SKIP_RESULT
                 continue
             EPS = 1e-3
+            sig_threshold = sig_threshold * pix_size_um
             if sigx_fit > sig_threshold + EPS or sigy_fit > sig_threshold + EPS:
                 fit_cache[cache_key] = _SKIP_RESULT
                 continue

--- a/utils.py
+++ b/utils.py
@@ -179,7 +179,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um=0.1
         if cached_result is not None:
             # A prior candidate already fit this PSF; skip duplicating it.
 
-            results.append(cached_result.copy)
+            results.append(cached_result.copy())
             continue
 
         # Extract finer subregion

--- a/utils.py
+++ b/utils.py
@@ -283,12 +283,12 @@ def integrate_sif(
             continue
         x0_guess = center_x_refined * pix_size_um
         y0_guess = center_y_refined * pix_size_um
-        sigma_guess = 0.3
+        sigma_ub = 0.3  # bounds expressed in microns to match coordinate scaling
+        sigma_guess = min(0.3, 0.95 * sigma_ub)
         p0 = [amp_guess, x0_guess, sigma_guess, y0_guess, sigma_guess, offset_guess]
 
         # Fit
         try:
-            sigma_ub = 0.3 * pix_size_um
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
             ub = [2 * amp_guess, x0_guess + 1, sigma_ub, y0_guess + 1, sigma_ub, offset_guess * 1.2]
@@ -307,7 +307,6 @@ def integrate_sif(
                 fit_cache[cache_key] = _SKIP_RESULT
                 continue
             EPS = 1e-3
-            sig_threshold = sig_threshold * pix_size_um
             if sigx_fit > sig_threshold + EPS or sigy_fit > sig_threshold + EPS:
                 fit_cache[cache_key] = _SKIP_RESULT
                 continue

--- a/utils.py
+++ b/utils.py
@@ -124,6 +124,8 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
         y_idx, x_idx = np.indices(sub_img_fine.shape)
         x_coords = (x_idx + x0_idx_fine) * pix_size_um
         y_coords = (y_idx + y0_idx_fine) * pix_size_um
+        x_flat = x_coords.ravel()
+        y_flat = y_coords.ravel()
         z_flat  = sub_img_fine.ravel()
 
         # Initial guess

--- a/utils.py
+++ b/utils.py
@@ -55,7 +55,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
     # Normalize counts → photons
     image_data_cps = image_data * (5.0 / gainDAC) / exposure_time / accumulate_cycles
 
-    radius_um_fine = 0.4
+    radius_um_fine = 0.5
     radius_pix_fine = int(radius_um_fine / pix_size_um)
 
     # --- Crop image if region specified ---

--- a/utils.py
+++ b/utils.py
@@ -75,7 +75,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
 
     # --- Detect peaks ---
     smoothed_image = gaussian_filter(image_data_cps, sigma=1)
-    threshold_abs = np.mean(smoothed_image) + threshold * np.std(smoothed_image)
+    threshold_abs = np.mean(smoothed_image) + threshold * np.std(smoothed_image)*0.1
 
     if signal == 'UCNP':
         coords = peak_local_max(smoothed_image, min_distance=5, threshold_abs=threshold_abs)

--- a/utils.py
+++ b/utils.py
@@ -115,14 +115,14 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
             exclude_border=False
         )
 
-    if local_peaks.shape[0] > 1:
-        # enqueue each local maximum as its own candidate (translated to image coords)
-        for ly, lx in local_peaks:
-            ny = y0_idx + ly
-            nx = x0_idx + lx
-            # skip if extremely close to any already-known coord
-            if all((abs(ny - cy) > 1 or abs(nx - cx) > 1) for cy, cx in coords):
-                coords.append((ny, nx))
+        if local_peaks.shape[0] > 1:
+            # enqueue each local maximum as its own candidate (translated to image coords)
+            for ly, lx in local_peaks:
+                ny = y0_idx + ly
+                nx = x0_idx + lx
+                # skip if extremely close to any already-known coord
+                if all((abs(ny - cy) > 1 or abs(nx - cx) > 1) for cy, cx in coords):
+                    coords.append((ny, nx))
         continue  # don't fit the ambiguous merged center; handle the new ones
 
 

--- a/utils.py
+++ b/utils.py
@@ -148,7 +148,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
                 return model - z
 
             lb = [1, x0_guess - 1, 0.0, y0_guess - 1, 0.0, 0.0]
-            ub = [2 * amp_guess, x0_guess + 1, 0.6, y0_guess + 1, 0.6, offset_guess * 1.2]
+            ub = [2 * amp_guess, x0_guess + 1, 0.8, y0_guess + 1, 0.8, offset_guess * 1.2]
 
             # Perform fit
             res = least_squares(residuals, p0, args=(x_flat, y_flat, z_flat), bounds=(lb, ub))

--- a/utils.py
+++ b/utils.py
@@ -120,6 +120,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
         # x_flat = x_coords.ravel()
         # y_flat = y_coords.ravel()
         # z_flat = sub_img_interp.ravel() #∆ variable name 250604
+        # switch from interp to fitting pixels 250916, noted that we were understimating brightness
         y_idx, x_idx = np.indices(sub_img_fine.shape)
         x_coords = (x_idx + x0_idx_fine) * pix_size_um
         y_coords = (y_idx + y0_idx_fine) * pix_size_um

--- a/utils.py
+++ b/utils.py
@@ -166,7 +166,7 @@ def integrate_sif(sif, threshold=1, region='all', signal='UCNP', pix_size_um = 0
             brightness_integrated = np.sum(sub_img_fine) - sub_img_fine.size * roi_min
             #brightness_integrated = np.sum(sub_img_fine) - sub_img_fine.size * offset_fit
 
-            if brightness_integrated > 1e9 or brightness_integrated < 50:
+            if brightness_integrated > 1e9 or brightness_integrated < 1:
                 print(f"Excluded peak for brightness {brightness_integrated:.2e}")
                 continue
             EPS = 1e-3


### PR DESCRIPTION
## Summary
- keep the Gaussian width guess and upper bound in the same micron units used during fitting
- compare fitted sigmas against the micron-scale threshold without unnecessary pixel conversion

## Testing
- python - <<'PY'
import numpy as np
import psyfit.utils as utils

call_count = {}

def fake_np_open(path, ignore_corrupt=True):
    img = np.zeros((1, 512, 512), dtype=np.float32)
    yy, xx = np.indices((512, 512))
    cx, cy = 256, 260
    amp = 5000.0
    sigma = 1.5
    gaussian = amp * np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma ** 2))
    img[0] = gaussian
    metadata = {
        'GainDAC': 1,
        'ExposureTime': 1.0,
        'AccumulatedCycles': 1,
    }
    call_count['calls'] = call_count.get('calls', 0) + 1
    return img, metadata

utils.sif_parser.np_open = fake_np_open

df, image = utils.integrate_sif('synthetic.sif', pix_size_um=0.1, sig_threshold=0.3)
print('np_open calls:', call_count['calls'])
print('fit count:', len(df))
print(df[['sigx_fit', 'sigy_fit']].head())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cda6f0c7688320ac41105575485fc9